### PR TITLE
fix(satUniBTC): correct name and symbol for Ethereum

### DIFF
--- a/data/ethereum.1/tokenlist.json
+++ b/data/ethereum.1/tokenlist.json
@@ -120,9 +120,9 @@
       {
         "chainId": 1,
         "address": "0xF7De2B7afdb07AA5dD143180Ed758165821E076e",
-        "symbol": "satUniBTC.e",
+        "symbol": "satUniBTC",
         "decimals": 8,
-        "name": "SatLayer uniBTC Bridged",
+        "name": "Satlayer uniBTC",
         "logoURI": "https://raw.githubusercontent.com/unionlabs/token-lists/main/logos/uniBTC.svg"
       }
     ],


### PR DESCRIPTION
Misunderstood the requirement.
The .e suffix was only for Babylon. Reverted the Ethereum asset name and symbol.